### PR TITLE
Fix for "Strict Standards..." error

### DIFF
--- a/class.drop-down-pages.php
+++ b/class.drop-down-pages.php
@@ -67,7 +67,7 @@ class EPS_Walker_PageDropdown extends Walker {
     var $tree_type = 'page';
     var $db_fields = array ('parent' => 'post_parent', 'id' => 'ID');
 
-    function start_el(&$output, $page, $depth, $args, $id = 0) {
+    function start_el(&$output, $page, $depth = 0, $args = Array(), $current_object_id = 0) {
         $pad = str_repeat('&nbsp;', $depth * 3);
         $output[$page->ID] = $pad . esc_html( apply_filters( 'list_pages', $page->post_title, $page ) );
     }


### PR DESCRIPTION
Fix for the error:

```
Strict Standards: Declaration of EPS_Walker_PageDropdown::start_el() should be compatible with Walker::start_el(&$output, $object, $depth = 0, $args = Array, $current_object_id = 0)
```

https://wordpress.org/support/topic/php-strict-standards-error-1?replies=1
